### PR TITLE
Fixed compiler errors and warnings

### DIFF
--- a/ADClusterMapView/ADMapCluster.m
+++ b/ADClusterMapView/ADMapCluster.m
@@ -20,6 +20,8 @@
 @implementation ADMapCluster
 @synthesize clusterCoordinate = _clusterCoordinate;
 @synthesize annotation = _annotation;
+@synthesize depth = _depth;
+
 - (id)initWithAnnotations:(NSArray *)annotations atDepth:(NSInteger)depth inMapRect:(MKMapRect)mapRect gamma:(double)gamma clusterTitle:(NSString *)clusterTitle {
     self = [super init];
     if (self) {

--- a/ADClusterMapView/ADMapPointAnnotation.m
+++ b/ADClusterMapView/ADMapPointAnnotation.m
@@ -9,6 +9,9 @@
 #import "ADMapPointAnnotation.h"
 
 @implementation ADMapPointAnnotation
+@synthesize mapPoint = _mapPoint;
+@synthesize annotation = _annotation;
+
 - (id)initWithAnnotation:(id<MKAnnotation>)annotation {
     self = [super init];
     if (self) {

--- a/ClusterDemo/Classes/CDAppDelegate.m
+++ b/ClusterDemo/Classes/CDAppDelegate.m
@@ -12,6 +12,7 @@
 #import "CDStreetlightsMapViewController.h"
 
 @implementation CDAppDelegate
+@synthesize window = _window;
 
 - (void)dealloc {
     [_window release];


### PR DESCRIPTION
In Xcode 4.3.2, the ClusterDemo project gives 8 compiler errors and 5 warnings.  All of these can be fixed with a few @synthesize statements.
