### PR TITLE
Fixed crash when delegate doesn't respond to mapView:viewForAnnotation:

### DIFF
--- a/ADClusterMapView/ADClusterMapView.m
+++ b/ADClusterMapView/ADClusterMapView.m
@@ -163,7 +163,12 @@
 	}
     // only leaf clusters have annotations
     if (((ADClusterAnnotation *)annotation).type == ADClusterAnnotationTypeLeaf || ![_secondaryDelegate respondsToSelector:@selector(mapView:viewForClusterAnnotation:)]) {
-        return [_secondaryDelegate mapView:self viewForAnnotation:annotation];
+        if ([_secondaryDelegate respondsToSelector:@selector(mapView:viewForAnnotation:)]) {
+            return [_secondaryDelegate mapView:self viewForAnnotation:annotation];
+        }
+        else {
+            return nil;
+        }
     } else {
         return [_secondaryDelegate mapView:self viewForClusterAnnotation:annotation];
     }


### PR DESCRIPTION
Regarding to the iOS documentation the delegate method "mapView:viewForAnnotation:" (MKMapViewDelegate) isn't a required method so there must be an if-statement checking if the delegate responds to "mapView:viewForAnnotation:" otherwise the default (nil) has to be returned.
