### PR TITLE
Added delegate method to set visibility of cluster annotation's subtitle

### DIFF
--- a/ADClusterMapView/ADClusterMapView.h
+++ b/ADClusterMapView/ADClusterMapView.h
@@ -16,6 +16,7 @@
 @optional
 - (NSInteger)numberOfClustersInMapView:(ADClusterMapView *)mapView; // default: 32
 - (MKAnnotationView *)mapView:(ADClusterMapView *)mapView viewForClusterAnnotation:(id <MKAnnotation>)annotation; // default: same as returned by mapView:viewForAnnotation:
+- (BOOL)shouldShowSubtitleForClusterAnnotationsInMapView:(ADClusterMapView *)mapView; // default: YES
 - (double)clusterDiscriminationPowerForMapView:(ADClusterMapView *)mapView; // This parameter emphasize the discrimination of annotations which are far away from the center of mass. default: 1.0 (no discrimination applied)
 - (NSString *)clusterTitleForMapView:(ADClusterMapView *)mapView; // default : @"%d elements"
 - (void)clusterAnimationDidStopForMapView:(ADClusterMapView *)mapView;

--- a/ADClusterMapView/ADClusterMapView.m
+++ b/ADClusterMapView/ADClusterMapView.m
@@ -76,7 +76,15 @@
             [mapPointAnnotation release];
         }
         [_rootMapCluster release];
-        _rootMapCluster = [[ADMapCluster rootClusterForAnnotations:mapPointAnnotations gamma:gamma clusterTitle:clusterTitle] retain];
+        
+        // Setting visibility of cluster annotations subtitle (defaults to YES)
+        BOOL shouldShowSubtitle = YES;
+        if ([_secondaryDelegate respondsToSelector:@selector(shouldShowSubtitleForClusterAnnotationsInMapView:)]) {
+            shouldShowSubtitle = [_secondaryDelegate shouldShowSubtitleForClusterAnnotationsInMapView:self];
+        }
+        
+        _rootMapCluster = [[ADMapCluster rootClusterForAnnotations:mapPointAnnotations gamma:gamma clusterTitle:clusterTitle showSubtitle:shouldShowSubtitle] retain];
+        
         [mapPointAnnotations release];
         dispatch_async(dispatch_get_main_queue(), ^{
             [self _clusterInMapRect:self.visibleMapRect];

--- a/ADClusterMapView/ADMapCluster.h
+++ b/ADClusterMapView/ADMapCluster.h
@@ -25,8 +25,9 @@
 @property (nonatomic, retain) ADMapPointAnnotation * annotation;
 @property (nonatomic, readonly) NSMutableArray * originalAnnotations;
 @property (nonatomic, readonly) NSInteger depth;
-- (id)initWithAnnotations:(NSArray *)annotations atDepth:(NSInteger)depth inMapRect:(MKMapRect)mapRect gamma:(double)gamma clusterTitle:(NSString *)clusterTitle;
-+ (ADMapCluster *)rootClusterForAnnotations:(NSArray *)annotations gamma:(double)gamma clusterTitle:(NSString *)clusterTitle;
+@property (nonatomic, assign) BOOL showSubtitle;
+- (id)initWithAnnotations:(NSArray *)annotations atDepth:(NSInteger)depth inMapRect:(MKMapRect)mapRect gamma:(double)gamma clusterTitle:(NSString *)clusterTitle showSubtitle:(BOOL)showSubtitle;
++ (ADMapCluster *)rootClusterForAnnotations:(NSArray *)annotations gamma:(double)gamma clusterTitle:(NSString *)clusterTitle showSubtitle:(BOOL)showSubtitle;
 - (NSArray *)find:(NSInteger)N childrenInMapRect:(MKMapRect)mapRect;
 - (NSArray *)children;
 - (BOOL)isAncestorOf:(ADMapCluster *)mapCluster;

--- a/ADClusterMapView/ADMapCluster.m
+++ b/ADClusterMapView/ADMapCluster.m
@@ -22,12 +22,13 @@
 @synthesize annotation = _annotation;
 @synthesize depth = _depth;
 
-- (id)initWithAnnotations:(NSArray *)annotations atDepth:(NSInteger)depth inMapRect:(MKMapRect)mapRect gamma:(double)gamma clusterTitle:(NSString *)clusterTitle {
+- (id)initWithAnnotations:(NSArray *)annotations atDepth:(NSInteger)depth inMapRect:(MKMapRect)mapRect gamma:(double)gamma clusterTitle:(NSString *)clusterTitle showSubtitle:(BOOL)showSubtitle {
     self = [super init];
     if (self) {
         _depth = depth;
         _mapRect = mapRect;
         _clusterTitle = [clusterTitle retain];
+        _showSubtitle = showSubtitle;
         if (annotations.count == 0) {
             _leftChild = nil;
             _rightChild = nil;
@@ -189,8 +190,8 @@
             
             _clusterCoordinate = MKCoordinateForMapPoint(MKMapPointMake(XMean, YMean));
             
-            _leftChild = [[ADMapCluster alloc] initWithAnnotations:leftAnnotations atDepth:depth+1 inMapRect:leftMapRect gamma:gamma clusterTitle:clusterTitle];
-            _rightChild = [[ADMapCluster alloc] initWithAnnotations:rightAnnotations atDepth:depth+1 inMapRect:rightMapRect gamma:gamma clusterTitle:clusterTitle];
+            _leftChild = [[ADMapCluster alloc] initWithAnnotations:leftAnnotations atDepth:depth+1 inMapRect:leftMapRect gamma:gamma clusterTitle:clusterTitle showSubtitle:showSubtitle];
+            _rightChild = [[ADMapCluster alloc] initWithAnnotations:rightAnnotations atDepth:depth+1 inMapRect:rightMapRect gamma:gamma clusterTitle:clusterTitle showSubtitle:showSubtitle];
             
             [leftAnnotations release];
             [rightAnnotations release];
@@ -207,7 +208,7 @@
     [super dealloc];
 }
 
-+ (ADMapCluster *)rootClusterForAnnotations:(NSArray *)initialAnnotations gamma:(double)gamma clusterTitle:(NSString *)clusterTitle {
++ (ADMapCluster *)rootClusterForAnnotations:(NSArray *)initialAnnotations gamma:(double)gamma clusterTitle:(NSString *)clusterTitle showSubtitle:(BOOL)showSubtitle {
     // KDTree
     
     MKMapRect boundaries = MKMapRectWorld;
@@ -231,7 +232,7 @@
     }
     
     NSLog(@"Computing KD-tree...");
-    ADMapCluster * cluster = [[ADMapCluster alloc] initWithAnnotations:initialAnnotations atDepth:0 inMapRect:boundaries gamma:gamma clusterTitle:clusterTitle];
+    ADMapCluster * cluster = [[ADMapCluster alloc] initWithAnnotations:initialAnnotations atDepth:0 inMapRect:boundaries gamma:gamma clusterTitle:clusterTitle showSubtitle:showSubtitle];
     NSLog(@"Computation done !");
     return [cluster autorelease];
 }
@@ -323,14 +324,19 @@
 }
 
 - (NSString *)subtitle {
-    if (!self.annotation) {
-        return [[self namesOfChildren] componentsJoinedByString:@", "];
-    } else {
-        if ([self.annotation.annotation respondsToSelector:@selector(subtitle)]) {
-            return self.annotation.annotation.subtitle;
+    if (self.showSubtitle) {
+        if (!self.annotation) {
+            return [[self namesOfChildren] componentsJoinedByString:@", "];
         } else {
-            return nil;
+            if ([self.annotation.annotation respondsToSelector:@selector(subtitle)]) {
+                return self.annotation.annotation.subtitle;
+            } else {
+                return nil;
+            }
         }
+    }
+    else {
+        return nil;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ We provide you with a few optional methods that you may want to add to your `ADC
 - (NSString *)clusterTitleForMapView:(ADClusterMapView *)mapView; // default : @"%d elements"
 ```
 
+### Set visibility for cluster annotation's subtitle
+
+```objective-c
+- (BOOL)shouldShowSubtitleForClusterAnnotationsInMapView:(ADClusterMapView *)mapView; // default: YES
+```
+
 ### Disminish outliers weight
 
 ```objective-c


### PR DESCRIPTION
I'm currently working on a project where I needed the ability to hide the subtitle of cluster annotations and only show a title with the format "%d shops". So I implemented an optional delegate method:

``` objective-c
- (BOOL)shouldShowSubtitleForClusterAnnotationsInMapView:(ADClusterMapView *)mapView; // default: YES
```

It's called from the ADClusterMapView just before initializing the rootMapCluster.

I think that the ability could be helpful for others too.
