### PR TITLE
Fixes bug with the new delegate method.

### DIFF
--- a/ADClusterMapView/ADMapCluster.m
+++ b/ADClusterMapView/ADMapCluster.m
@@ -324,20 +324,12 @@
 }
 
 - (NSString *)subtitle {
-    if (self.showSubtitle) {
-        if (!self.annotation) {
-            return [[self namesOfChildren] componentsJoinedByString:@", "];
-        } else {
-            if ([self.annotation.annotation respondsToSelector:@selector(subtitle)]) {
-                return self.annotation.annotation.subtitle;
-            } else {
-                return nil;
-            }
-        }
+    if (!self.annotation && self.showSubtitle) {
+        return [[self namesOfChildren] componentsJoinedByString:@", "];
+    } else if ([self.annotation.annotation respondsToSelector:@selector(subtitle)]) {
+        return self.annotation.annotation.subtitle;
     }
-    else {
-        return nil;
-    }
+    return nil;
 }
 
 - (NSInteger)numberOfChildren {


### PR DESCRIPTION
The subtitles should be shown for all normal annotations and should only be hidden for cluster annotations if the delegate returns NO.
