### PR TITLE
Do not crash when no cluster title is provided.

### DIFF
--- a/ADClusterMapView/ADMapCluster.m
+++ b/ADClusterMapView/ADMapCluster.m
@@ -313,14 +313,15 @@
 
 - (NSString *)title {
     if (!self.annotation) {
-        return [NSString stringWithFormat:_clusterTitle, [self numberOfChildren]];
+        if (_clusterTitle) {
+            return [NSString stringWithFormat:_clusterTitle, [self numberOfChildren]];
+        }
     } else {
         if ([self.annotation.annotation respondsToSelector:@selector(title)]) {
             return self.annotation.annotation.title;
-        } else {
-            return nil;
         }
     }
+    return nil;
 }
 
 - (NSString *)subtitle {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bugfixes:
 
   - Fix potential crash during animations (@scheinem)
   - Fix a bug when an ADClusterAnnotation instance had no cluster assigned in `mapView:viewForAnnotation:`
+  - Fix crash when the view is deallocated and the private `MKMapAnnotationManager` class still tries to update a selected annotation. (@alloy)
 
 Features:
 


### PR DESCRIPTION
This happens when an annotation was selected (the callout is shown) and the view deallocates. It seems the private `MKMapAnnotationManager` class still ends up calling this `title` method, which in my case has no custom title, leading to an exception in `+[NSString stringWithFormat]`.

/cc @jeffkreeftmeijer 
